### PR TITLE
Specify memory regions for `.Reset` and `.PreResetTrampoline`

### DIFF
--- a/xmc.x.in
+++ b/xmc.x.in
@@ -88,6 +88,9 @@ SECTIONS
   /* ### .text */
   .text _stext :
   {
+    *(.PreResetTrampoline)
+    *(.Reset);
+
     *(.text .text.*);
     *(.HardFaultTrampoline);
     *(.HardFault.*);


### PR DESCRIPTION
shamelessly copied this from the cortex-m-rt linker file

without them the linker throws errors.

In newer versions of cortex-m-rt you only need the reset region specified, but this works with the current version, and I didn't want to create a PR in xmc1100-rs to update the cortex-m-rt version there too.